### PR TITLE
Fix for Joomla! v5 (Replace JFactory)

### DIFF
--- a/asmnoadmin.php
+++ b/asmnoadmin.php
@@ -17,10 +17,10 @@ class plgSystemAsmNoAdmin extends CMSPlugin {
 	public function onAfterInitialise() {
 		// this is for Ajax petitions
 		if( isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') return;		
-		$app	= JFactory::getApplication();	
+		$app	= Factory::getApplication();	
 
 		// if client is administrator && not guest OR site return
-		if(($app->isClient('administrator') && !JFactory::getUser()->guest) || $app->isClient('site')) {
+		if(($app->isClient('administrator') && !Factory::getUser()->guest) || $app->isClient('site')) {
 			return;	
 		}
 		else {		
@@ -36,4 +36,3 @@ class plgSystemAsmNoAdmin extends CMSPlugin {
 	}
 	
 }
-?>

--- a/asmnoadmin.xml
+++ b/asmnoadmin.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License</license>
     <authorEmail>info@algosemueve.es</authorEmail>
     <authorUrl>https://algosemueve.es</authorUrl>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>Simple plugin to hide the administrator login.</description>
 
     <files>
@@ -41,6 +41,6 @@
         </fields>
     </config>
     <updateservers>
-        <server type="extension" priority="1" name="ASM Update Site">https://algosemueve/updates/asmnoadmin.xml</server>
+        <server type="extension" priority="1" name="ASM Update Site">https://algosemueve.es/updates/asmnoadmin.xml</server>
     </updateservers>
 </extension>


### PR DESCRIPTION
Updates JFactory references to Factory to fix errors in Joomla! v5 when running without backward compatibility plug-in enabled.